### PR TITLE
feat: add Core as supported ApplicationName for core team

### DIFF
--- a/etc/features-component.api.md
+++ b/etc/features-component.api.md
@@ -15,6 +15,8 @@ export enum ApplicationName {
     // (undocumented)
     BUILDER = "builder",
     // (undocumented)
+    CORE = "core",
+    // (undocumented)
     DAO = "dao",
     // (undocumented)
     DAPPS = "dapps",

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,7 @@ export enum ApplicationName {
   EVENTS = "events",
   LANDING = "landing",
   TEST = "test",
+  CORE = "core"
 }
 
 /**


### PR DESCRIPTION
Add `Core` as new `ApplicationName` to support feature flags from Core team.